### PR TITLE
Add keybinding to switch between TAM and MT files

### DIFF
--- a/plugin/miniTriangle/sections.vim
+++ b/plugin/miniTriangle/sections.vim
@@ -1,0 +1,2 @@
+" adapted from http://vim.wikia.com/wiki/Easily_switch_between_source_and_header_file#Single_line_solution
+nnoremap <F4> :e %:p:s,.mt$,.X123X,:s,.tam$,.mt,:s,.X123X$,.tam,<CR>


### PR DESCRIPTION
Add a keybinding, <F4> by default, which allows users to switch between
their MiniTriangle (MT) source code, and Triangle Abstract Machine
(TAM) files.

Adapted from code in
http://vim.wikia.com/wiki/Easily_switch_between_source_and_header_file#Single_line_solution
